### PR TITLE
Nodejs 6.10 deprecated

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -10,7 +10,7 @@ backend:
         - USER_BASE_PATH=$(python3.6 -m site --user-base)
         - export PATH=$PATH:$USER_BASE_PATH/bin
         - python3.6 -m pip install aws-sam-cli
-        - export TMDB_API_KEY=3f883f36d2cb8dc07cd3cc322648dc84 # Replace it with your TMDb API Key
+        - export TMDB_API_KEY=43cd3d358601977d8aaf660f0c85934a # Replace it with your TMDb API Key
         - export AWS_REGION=$(jq -r '.providers.awscloudformation.Region' amplify/#current-cloud-backend/amplify-meta.json)
         - export GRAPHQL_API_ID=$(jq -r '.api[(.api | keys)[0]].output.GraphQLAPIIdOutput' ./amplify/#current-cloud-backend/amplify-meta.json)
         - export GRAPHQL_API_NAME=$(aws appsync get-graphql-api --api-id $GRAPHQL_API_ID --region $AWS_REGION | jq -r '.graphqlApi.name')

--- a/amplify.yml
+++ b/amplify.yml
@@ -10,7 +10,7 @@ backend:
         - USER_BASE_PATH=$(python3.6 -m site --user-base)
         - export PATH=$PATH:$USER_BASE_PATH/bin
         - python3.6 -m pip install aws-sam-cli
-        - export TMDB_API_KEY=43cd3d358601977d8aaf660f0c85934a # Replace it with your TMDb API Key
+        - export TMDB_API_KEY=3f883f36d2cb8dc07cd3cc322648dc84 # Replace it with your TMDb API Key
         - export AWS_REGION=$(jq -r '.providers.awscloudformation.Region' amplify/#current-cloud-backend/amplify-meta.json)
         - export GRAPHQL_API_ID=$(jq -r '.api[(.api | keys)[0]].output.GraphQLAPIIdOutput' ./amplify/#current-cloud-backend/amplify-meta.json)
         - export GRAPHQL_API_NAME=$(aws appsync get-graphql-api --api-id $GRAPHQL_API_ID --region $AWS_REGION | jq -r '.graphqlApi.name')

--- a/amplify/backend/auth/cognito320c7b90/cognito320c7b90-cloudformation-template.yml
+++ b/amplify/backend/auth/cognito320c7b90/cognito320c7b90-cloudformation-template.yml
@@ -264,7 +264,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole

--- a/amplify/backend/auth/cognito320c7b90/cognito320c7b90-cloudformation-template.yml
+++ b/amplify/backend/auth/cognito320c7b90/cognito320c7b90-cloudformation-template.yml
@@ -264,7 +264,7 @@ Resources:
             - ' }'
             - '};'
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs6.10
       Timeout: '300'
       Role: !GetAtt 
         - UserPoolClientRole


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Nodejs 6.10 Lambda runtime has been deprecated, causing the build process in Amplify console to fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
