### PR TITLE
replaces all versions of nodejs to 10.x 

### DIFF
--- a/amplify/backend/auth/realtime99d78ebe/realtime99d78ebe-cloudformation-template.yml
+++ b/amplify/backend/auth/realtime99d78ebe/realtime99d78ebe-cloudformation-template.yml
@@ -246,7 +246,7 @@ Resources:
             - " }"
             - "};"
       Handler: index.handler
-      Runtime: nodejs8.10
+      Runtime: nodejs10.x
       Timeout: "300"
       Role: !GetAtt
         - UserPoolClientRole

--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -53,7 +53,7 @@ Resources:
         Properties:
             CodeUri: get-movie/
             Handler: app.lambdaHandler
-            Runtime: nodejs8.10
+            Runtime: nodejs10.x
             Role: !GetAtt [ LambdaExecutionRole, Arn ]
             Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
                 Variables:


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #5 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
