### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/amplify/backend/auth/realtime99d78ebe/realtime99d78ebe-cloudformation-template.yml
+++ b/amplify/backend/auth/realtime99d78ebe/realtime99d78ebe-cloudformation-template.yml
@@ -246,7 +246,7 @@ Resources:
             - " }"
             - "};"
       Handler: index.handler
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Timeout: "300"
       Role: !GetAtt
         - UserPoolClientRole

--- a/sam-app/template.yaml
+++ b/sam-app/template.yaml
@@ -53,7 +53,7 @@ Resources:
         Properties:
             CodeUri: get-movie/
             Handler: app.lambdaHandler
-            Runtime: nodejs10.x
+            Runtime: nodejs14.x
             Role: !GetAtt [ LambdaExecutionRole, Arn ]
             Environment: # More info about Env Vars: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#environment-object
                 Variables:


### PR DESCRIPTION
CloudFormation templates in appsync-refarch-realtime have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.